### PR TITLE
Suppress table altogether if no rows are relevant for $ruser.

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,8 @@ student-2,lab2,99%
 Students will see all rows that have `cwlid` matching their CWL ID.
 
 For example, student-1 will see only:
-```
-{"cwlid":"student-1","assignment":"lab1","grade":"100%"}
-{"cwlid":"student-1","assignment":"lab2","grade":"100%"}
-```
+| cwlid     | assignment | grade |
+| --------- | ---------- | ----- |
+| student-1 | lab1       | 100%  |
+| student-1 | lab2       | 100%  |
+

--- a/index.php
+++ b/index.php
@@ -50,6 +50,7 @@ function showGrades($ruser, $csvFile)
 {
     # Show lines from the csvFile where cwlid=$ruser
     $html = "";
+    $anyRows = False;
     try {
         $csv = array_map("str_getcsv", file($csvFile, FILE_SKIP_EMPTY_LINES));
         # start table
@@ -71,6 +72,7 @@ function showGrades($ruser, $csvFile)
             $rowDict = array_combine($header, $row);
             if (!empty($rowDict['cwlid']) && $rowDict['cwlid'] === $ruser) {
 	        # yes, render the row in the table
+                $anyRows = True;
                 $html .= '<tr>';
                 foreach($row as $i=>$entry){
                     $html .= '<td>' . htmlspecialchars($entry) . '</td>';
@@ -84,7 +86,11 @@ function showGrades($ruser, $csvFile)
         error_log('There was a problem processing ' . $csvFile . " - " . $e->getMessage());
         $html .= "There was a problem processing the grades file!\n";
     }
-    return $html;
+    if($anyRows) {
+        return $html;
+    } else {
+        return "";
+    }
 }
 
 $ruser = $_SERVER['REMOTE_USER'];


### PR DESCRIPTION
As per previous observation, the table header prints if there are no
relevant rows, which is ugly and leaks information.  This change
discards the table if no rows were produced.
